### PR TITLE
fix: avoid stripping out full path if file extension not included

### DIFF
--- a/packages/common/src/utils.ts
+++ b/packages/common/src/utils.ts
@@ -61,7 +61,7 @@ export const getNotebookPath = (): string => {
 
     if (isGitRefSpecified()) {
       // Strip the file extension from the notebook path.
-      return localNotebookPath.split('.').slice(0, -1).join('.')
+      return localNotebookPath.split('.').slice(0, -1).join('.') || localNotebookPath
     } else {
       return localNotebookPath
     }


### PR DESCRIPTION
Quick fix to address https://github.com/databricks/run-notebook/issues/48